### PR TITLE
Image Scaling Regex

### DIFF
--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -243,9 +243,8 @@ namespace azuredevops_export_wiki
                 var md = File.ReadAllText(file.FullName);
 
                 // remove scalings from image links
-                //md = Regex.Replace(md, @"\.(.*?) =.*x.*\)", @".$1)", RegexOptions.Singleline);
-                var regexImageScalings = @"(?<=png|jpg|jpeg)(.*?) =.*x.[^\)]*";
-                md = Regex.Replace(md, regexImageScalings, String.Empty);
+                var regexImageScalings = @"\(((.[^\)]*?(png|jpg|jpeg))( =((\d+).*x(\d+).*)))\)";
+                md = Regex.Replace(md, regexImageScalings, @"($2){width=$6 height=$7}");
 
                 //setup the markdown pipeline to support tables
                 var pipeline = new MarkdownPipelineBuilder()

--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -244,6 +244,8 @@ namespace azuredevops_export_wiki
 
                 // remove scalings from image links
                 //md = Regex.Replace(md, @"\.(.*?) =.*x.*\)", @".$1)", RegexOptions.Singleline);
+                var regexImageScalings = @"(?<=png|jpg|jpeg)(.*?) =.*x.[^\)]*";
+                md = Regex.Replace(md, regexImageScalings, String.Empty);
 
                 //setup the markdown pipeline to support tables
                 var pipeline = new MarkdownPipelineBuilder()


### PR DESCRIPTION
### Description
Handles images with scaling attributes. The images with scaling attributes were currently ignored during conversion. Added an updated regex expression that handles this use-case. Tested on an internal wiki with 250+ pages and the conversion appears to work fine.

The regex expression specifically looks for .png, jpg, jpeg inside the parenthesis. The Regex expression can be adjusted to add support for future image types supported by Azure DevOps wiki.

### Example
Below is a sample of the type of images that were not being converted. 

**Sample Input **
`[devenv_Lbh7sFVc7K.png](/.attachments/devenv_Lbh7sFVc7K-a56f4c07-8738-4ab4-a363-12df4b9c05fe.png =90%x100%)`
**Sample Output**
`[devenv_Lbh7sFVc7K.png](/.attachments/devenv_Lbh7sFVc7K-a56f4c07-8738-4ab4-a363-12df4b9c05fe.png){width=90 height=100}`