### PR TITLE
Check null for LinkInLine identified but without Url

### DIFF
--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -349,50 +349,52 @@ namespace azuredevops_export_wiki
             // and relative links to markdown pages
             foreach (var link in document.Descendants().OfType<LinkInline>())
             {
-                if (!link.Url.StartsWith("http"))
+                if (link.Url != null)
                 {
+                    if (!link.Url.StartsWith("http"))
+                    {
 
-                    string absPath = null;
+                        string absPath = null;
 
-                    if (link.Url.StartsWith("/"))
-                    {
-                        absPath = Path.GetFullPath(_path + link.Url);
-                    }
-                    else
-                    {
-                        absPath = Path.GetFullPath(file.Directory.FullName + "/" + link.Url);
-                    }
-                    //the file is a markdown file, create a link to it
-                    var isMarkdown = false;
-                    var fileInfo = new FileInfo(absPath);
-                    if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        isMarkdown = true;
-                    }
-                    else if (fileInfo.Exists)
-                    {
-                        link.Url = $"file:///{absPath}";
-                    }
+                        if (link.Url.StartsWith("/"))
+                        {
+                            absPath = Path.GetFullPath(_path + link.Url);
+                        }
+                        else
+                        {
+                            absPath = Path.GetFullPath(file.Directory.FullName + "/" + link.Url);
+                        }
+                        //the file is a markdown file, create a link to it
+                        var isMarkdown = false;
+                        var fileInfo = new FileInfo(absPath);
+                        if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            isMarkdown = true;
+                        }
+                        else if (fileInfo.Exists)
+                        {
+                            link.Url = $"file:///{absPath}";
+                        }
 
-                    fileInfo = new FileInfo($"{absPath}.md");
-                    if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        isMarkdown = true;
-                    }
+                        fileInfo = new FileInfo($"{absPath}.md");
+                        if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            isMarkdown = true;
+                        }
 
-                    //only markdown files get a pdf internal link
-                    if (isMarkdown)
-                    {
-                        var relPath = mf.RelativePath + "\\" + link.Url;
-                        relPath = relPath.Replace("/", "\\");
-                        relPath = relPath.Replace("\\", "");
-                        relPath = relPath.Replace(".md", "");
-                        relPath = relPath.ToLower();
-                        Log($"\tMarkdown link: {relPath}");
-                        link.Url = $"#{relPath}";
+                        //only markdown files get a pdf internal link
+                        if (isMarkdown)
+                        {
+                            var relPath = mf.RelativePath + "\\" + link.Url;
+                            relPath = relPath.Replace("/", "\\");
+                            relPath = relPath.Replace("\\", "");
+                            relPath = relPath.Replace(".md", "");
+                            relPath = relPath.ToLower();
+                            Log($"\tMarkdown link: {relPath}");
+                            link.Url = $"#{relPath}";
+                        }
                     }
                 }
-
                 CorrectLinksAndImages(link, file, mf);
             }
         }


### PR DESCRIPTION
With my wiki, the export was failing with the following exception

![image](https://user-images.githubusercontent.com/3492186/85564750-cf3f3b80-b62e-11ea-9bd2-3631a3d1c7b4.png)

The additional check null solves this.

