### PR TITLE
Fix error if relative path is root

### DIFF
--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -465,7 +465,7 @@ namespace azuredevops_export_wiki
             foreach (var orderFile in orderFiles)
             {
                 var orders = File.ReadAllLines(orderFile.FullName);
-                var relativePath = orderFile.Directory.FullName.Substring(directory.FullName.Length);
+                var relativePath = orderFile.Directory.FullName.Length > directory.FullName.Length ? orderFile.Directory.FullName.Substring(directory.FullName.Length) : "/";
                 foreach (var order in orders)
                 {
                     MarkdownFile mf = new MarkdownFile();


### PR DESCRIPTION
I ran into an error when running your script:

```
Reading .order file in directory docs
ERR: Something bad happend.
System.ArgumentOutOfRangeException: startIndex cannot be larger than length of string. (Parameter 'startIndex')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at System.String.Substring(Int32 startIndex)
   at azuredevops_export_wiki.WikiPDFExporter.ReadOrderFiles(String path) in D:\Git\WikiPDFExport\AzureDevOps.WikiPDFExport\WikiPDFExporter.cs:line 467
   at azuredevops_export_wiki.WikiPDFExporter.Export() in D:\Git\WikiPDFExport\AzureDevOps.WikiPDFExport\WikiPDFExporter.cs:line 85
```

This PR fixes issues if the relative path is at the root of `path`.