### PR TITLE
Sample and test markdown with Dev Ops wiki styling

### DIFF
--- a/sampleDevOps/.order
+++ b/sampleDevOps/.order
@@ -1,0 +1,2 @@
+contents
+learn

--- a/sampleDevOps/contents.md
+++ b/sampleDevOps/contents.md
@@ -1,0 +1,18 @@
+# Contents
+
+1. [Original file](/contents)
+2. [How to learn](/learn)
+3. How to automate provisioning
+4. How to edit pages
+5. How to make a build process that actually fixes stuff
+6. How to create a PDF from all this
+
+## Happy wiki-ing
+
+I don't know how to say this, but its awesome
+
+
+## How to create a PDF from all this?
+
+https://github.com/MaxMelcher/AzureDevOps.WikiPDFExport
+

--- a/sampleDevOps/contents/.order
+++ b/sampleDevOps/contents/.order
@@ -1,0 +1,3 @@
+placeholder
+Test
+emoji

--- a/sampleDevOps/contents/Test.md
+++ b/sampleDevOps/contents/Test.md
@@ -1,0 +1,661 @@
+# Test with markdown
+
+[[_TOC_]]
+
+The table of contents is not supported. Should render just the tag in PDF.
+
+## Guidance
+
+This page implements most of the markdown examples given on the [DevOps wiki docs](https://docs.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops)
+
+It is not claimed or stated that all these features should work. However, this a quite complete test for the PDF generation.
+
+At some points the official docs show images instead of the rendered content. I suspect that this is to support multiple browsers and even the 'print to PDF' functionality in a browser.
+
+## Headers
+
+Structure your comments using headers. Headers segment longer comments, making them easier to read.
+
+Start a line with a hash character `#` to set a heading. Organize your remarks with subheadings by starting a line with additional hash characters, for example `####`. Up to six levels of headings are supported.
+
+**Example:**
+```markdown
+# This is a H1 header
+## This is a H2 header
+### This is a H3 header
+#### This is a H4 header
+##### This is a H5 header
+```
+
+**Result:**
+
+# This a H1 header
+## This a H2 header
+### This a H3 header
+#### This a H4 header
+##### This a H5 header
+     
+
+## Paragraphs and line breaks
+
+
+Make your text easier to read by breaking it up with paragraphs or line breaks.  
+
+In pull request comments, select **Enter** to insert a line break, and begin text on a new line.
+
+In a Markdown file or widget, enter two spaces before the line break to begin a new paragraph, or enter two consecutive line breaks to begin a new paragraph.
+
+
+**Example - pull request comment:**
+
+<pre>
+Add lines between your text with the Enter key.
+This spaces your text better and makes it easier to read.
+</pre>
+
+**Result:**
+Add lines between your text with the Enter key.
+This action spaces your text better and makes it easier to read.
+
+**Example - Markdown file or widget:**
+
+<pre>
+Add two spaces before the end of the line.(space, space)
+This adds space in between paragraphs.
+</pre>
+
+**Result:**  
+Add two spaces before the end of the line.  
+Space is added in between paragraphs.
+
+## Blockquotes
+
+Quote previous comments or text to set the context for your comment or text.
+
+Quote single lines of text with `>` before the text. Use many `>` characters to nest quoted text.
+Quote blocks of lines of text by using the same level of `>` across many lines.
+
+**Example:**
+
+<pre>
+> Single line quote
+>> Nested quote
+>> multiple line
+>> quote
+</pre>
+
+**Result:**  
+
+> Single line quote
+>> Nested quote  
+>> multiple line  
+>> quote
+
+## Horizontal rules
+
+To add a horizontal rule, add a line that's a series of dashes `---`. The line above the line containing the `---` must be blank.
+
+**Example:**
+
+<div id="do_not_render">
+<pre>
+above
+&nbsp;
+&#45;&#45;&#45;&#45;
+below
+</pre>
+</div>
+
+**Result:**  
+
+above    
+
+-----    
+
+below    
+
+## Emphasis (bold, italics, strikethrough) 
+
+You can emphasize text by applying bold, italics, or strikethrough to characters:
+
+- To apply italics: surround the text with an asterisk `*` or underscore `_` 
+- To apply bold: surround the text with double asterisks `**`.
+- To apply strikethrough: surround the text with double tilde characters `~~`.
+
+Combine these elements to apply emphasis to text.
+
+
+> There is no Markdown syntax that supports underlining text. Within a wiki page, you can use the HTML `<u>` tag to generate underlined text. For example, `<u>underlined text</u>` yields <u>underlined text</u>.
+
+
+**Example:**
+
+<pre>
+Use _emphasis_ in comments to express **strong** opinions and point out ~~corrections~~  
+**_Bold, italicized text_**  
+**~~Bold, strike-through text~~**
+</pre>
+
+<br/>
+
+**Result:**  
+
+Use _emphasis_ in comments to express **strong** opinions and point out <s>corrections</s>  
+**_Bold, italicized text_**
+**~~Bold, strike-through text~~**  
+
+
+## Code highlighting
+
+
+Highlight suggested code segments using code highlight blocks.
+To indicate a span of code, wrap it with three backtick quotes (<code>&#96;&#96;&#96;</code>) on a new line at both the start and end of the block. To indicate code inline, wrap it with one backtick quote (<code>&#96;</code>).
+
+> Code highlighting entered within the Markdown widget renders code as plain preformatted text.
+
+
+**Example:**
+
+<pre>&#96;&#96;&#96;
+sudo npm install vsoagent-installer -g  
+&#96;&#96;&#96;
+</pre>  
+
+<br/>
+
+**Result:**
+
+```
+sudo npm install vsoagent-installer -g
+```
+
+<br/>
+
+**Example:**
+
+<pre>
+To install the Microsoft Cross Platform Build & Release Agent, run the following: &#96;$ sudo npm install vsoagent-installer -g&#96;.
+</pre>
+
+<br/>
+
+**Result:**
+
+To install the Microsoft Cross Platform Build & Release Agent, run the following command: `$ sudo npm install vsoagent-installer -g`.  
+
+<br/>
+
+Within a Markdown file, text with four spaces at the beginning of the line automatically converts to a code block.  
+
+Set a language identifier for the code block to enable syntax highlighting for any of the supported languages in [highlightjs](https://github.com/highlightjs/highlight.js/tree/9.10.0/src/languages), version v9.10.0.
+
+<pre>
+``` language
+code
+```
+</pre>
+
+<br/>
+
+**Additional examples:**
+
+<pre>
+``` js
+const count = records.length;
+```
+</pre>
+
+``` js
+const count = records.length;
+```
+
+<br/>
+
+<pre>
+``` csharp
+Console.WriteLine("Hello, World!");
+```
+</pre>
+
+``` csharp
+Console.WriteLine("Hello, World!");
+```
+
+
+## Tables
+
+
+Organize structured data with tables. Tables are especially useful for describing function parameters, object methods, and other data that have
+a clear name to description mapping. You can format tables in pull requests, wiki, and Markdown files such as README files and Markdown widgets.  
+
+- Place each table row on its own line
+- Separate table cells using the pipe character `|`
+- The first two lines of a table set the column headers and the alignment of elements in the table
+- Use colons (`:`) when dividing the header and body of tables to specify column alignment (left, center, right)
+- To start a new line, use the HTML break tag (`<br/>`) (Works within a Wiki but not elsewhere)  
+- Make sure to end each row with a CR or LF.
+- A blank space is required before and after work item or pull request (PR) mentions inside a table cell.
+
+**Example:**
+
+```markdown
+| Heading 1 | Heading 2 | Heading 3 |  
+|-----------|:-----------:|-----------:|  
+| Cell A1 | Cell A2 | Cell A3 |  
+| Cell B1 | Cell B2 | Cell B3<br/>second line of text |  
+```
+
+
+**Result:**  
+
+| Heading 1 | Heading 2 | Heading 3 |  
+|-----------|:---------:|-----------:|  
+| Cell A1 | Cell A2 | Cell A3 |  
+| Cell B1 | Cell B2 | Cell B3<br/>second line of text |  
+
+## Lists
+
+Organize related items with lists. You can add ordered lists with numbers, or unordered lists with just bullets.
+
+Ordered lists start with a number followed by a period for each list item. Unordered lists start with a `-`. Begin each list item on a new line. In a Markdown file or widget, enter two spaces before the line break to begin a new paragraph, or enter two line breaks consecutively to begin a new paragraph.
+
+### Ordered or numbered lists
+
+**Example:**
+
+```markdown
+1. First item.
+1. Second item.
+1. Third item.
+```
+
+**Result:**
+
+1. First item.
+2. Second item.
+3. Third item.
+
+### Bullet lists
+
+**Example:**
+
+```
+- Item 1
+- Item 2
+- Item 3
+```
+
+**Result:**
+
+- Item 1
+- Item 2
+- Item 3
+
+### Nested lists
+
+**Example:**
+
+```
+1. First item.
+   - Item 1
+   - Item 2
+   - Item 3
+1. Second item.
+   - Nested item 1
+   - Nested item 2
+   - Nested item 3 
+```
+
+**Result:**  
+
+1. First item.
+    - Item 1
+    - Item 2
+    - Item 3
+2. Second item.
+    - Nested item 1
+    - Nested item 2
+    - Nested item 3
+
+
+## Links
+
+In pull request comments and wikis, HTTP and HTTPS URLs are automatically formatted as links. You can link to work items by entering the *#* key and a work item ID, and then choosing the work item from the list.
+
+Avoid auto suggestions for work items by prefixing *#* with a backslash (`\`). This action can be useful if you want to use *#* for color hex codes.
+
+In Markdown files and widgets, you can set text hyperlinks for your URL using the standard Markdown link syntax:
+
+```markdown
+[Link Text](Link URL)
+```
+
+When linking to another Markdown page in the same Git or TFVC repository, the link target can be a relative path or an absolute path in the repository.  
+
+**Supported links for Welcome pages:**
+
+- Relative path: `[text to display](/target.md)` 
+- Absolute path in Git: `[text to display](/folder/target.md)`
+- Absolute path in TFVC: `[text to display]($/project/folder/target.md)`
+- URL: `[text to display](http://address.com)`
+
+**Supported links for Markdown widget:**
+
+<ul>
+<li>URL: <code>[text to display](http://address.com)</code>  </li>
+</ul>
+
+**Supported links for Wiki:**  
+<ul>
+<li>Absolute path of Wiki pages: <code>[text to display](/parent-page/child-page)</code> </li>
+<li>URL: <code>[text to display](http://address.com)</code>  </li>
+</ul>
+
+
+
+### Anchor links
+
+Within Markdown files, anchor IDs are assigned to all headings when rendered as HTML. The ID is the heading text, with the spaces replaced by dashes (-) and all lower case. In general, the following conventions apply:
+
+- Punctuation marks and leading white spaces within a file name are ignored
+- Upper case letters are  converted to lower
+- Spaces between letters are converted to dashes (-).
+
+**Example:**
+
+```
+###Link to a heading in the page
+```
+
+
+**Result:**
+
+The syntax for an anchor link to a section...
+
+<pre>
+[Link to a heading in the page](#link-to-a-heading-in-the-page)
+</pre>
+<br/>
+The ID is all lower case, and the link is case-sensitive, so be sure to use lower case, even though the heading itself uses upper case.
+
+You can also reference headings within another Markdown file:
+
+<pre>
+[text to display](./target.md#heading-id)  
+</pre>
+
+<br/>
+In wiki, you can also reference heading in another page:
+
+<pre>
+[text to display](/page-name#section-name)
+</pre>
+
+<a name="images"> </a>
+
+## Images
+
+
+To highlight issues or make things more interesting, you can add images and animated GIFs to the following aspects in your pull requests:
+
+- Comments
+- Markdown files
+- Wiki pages
+
+Use the following syntax to add an image: <div id="do_not_render"><pre>&#33;&#91;Text](URL)</pre></div> The text in the brackets describes the image being linked and the URL points to the image location.
+
+**Example:**
+
+<pre>
+![Illustration to use for new users](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
+</pre>
+
+
+
+**Result:**
+
+![Illustration of linked image](https://azurecomcdn.azureedge.net/cvt-779fa2985e70b1ef1c34d319b505f7b4417add09948df4c5b81db2a9bad966e5/images/page/services/devops/hero-images/index-hero.jpg)
+
+The path to the image file can be a relative path or the absolute path in Git or TFVC, just like the path to another Markdown file in a link.  
+
+- Relative path: `![Image alt text](./image.png)`  
+- Absolute path in Git: `![Image alt text](/media/markdown-guidance/image.png)`  
+- Absolute path in TFVC: `![Image alt text]($/project/folder/media/markdown-guidance/image.png)`  
+- Resize image: `IMAGE_URL =WIDTHxHEIGHT`
+
+> Be sure to include a space before the equal sign.
+>
+
+- Example: `![Image alt text]($/project/folder/media/markdown-guidance/image.png =500x250)`
+- It's also possible to specify only the WIDTH by leaving out the HEIGHT value: `IMAGE_URL =WIDTHx`
+
+
+
+## Checklist or task list
+
+
+You can Use `[ ]` or `[x]` to support checklists. Precede the checklist with either `-<space>` or `1.<space>` (any numeral).
+
+
+**Example - Format a list as a task list**
+
+<pre>
+- [ ] A  
+- [ ] B  
+- [ ] C  
+- [x] A  
+- [x] B  
+- [x] C  
+</pre>
+
+
+**Result:**  
+
+- [ ] A  
+- [ ] B  
+- [ ] C  
+- [x] A  
+- [x] B  
+- [x] C  
+
+
+> A checklist within a table cell isn't supported.
+
+
+## Emoji
+
+**Example:**
+
+<pre>
+:smile:
+:angry:
+</pre>
+
+
+**Result:**  
+
+:smile:
+:angry:
+
+To escape emojis, enclose them using the \` character.
+
+**Example:**
+
+<pre>`:smile:` `:)` `:angry:`</pre>
+
+**Result:**
+
+ `:smile:` `:)` `:angry:`
+
+See a full list of emoji and how they render [on the Emoji page](./emoji.md#Full-set-of-Emoji)
+(this is also an example of a link wiht an anchor to another pase)
+
+
+## Ignore or escape Markdown syntax to enter specific or literal characters
+
+<table width="650px">
+<tbody valign="top">
+<tr>
+<th width="300px">Syntax</th>
+<th width="350px">Example/notes</th>
+</tr>
+<tr>
+<td>
+<p>To insert one of the following characters, prefix with a <code>&#92;</code>(backslash).</p>
+<p style="margin-bottom:2px;"><code>&#92;</code>, backslash </p>
+<p style="margin-bottom:2px;"><code>&#96;</code>, backtick</p>
+<p style="margin-bottom:2px;"><code>&#95;</code>, underscore</p>
+<p style="margin-bottom:2px;"><code>{}</code>, curly braces </p>
+<p style="margin-bottom:2px;"><code>[]</code>, square brackets</p>
+<p style="margin-bottom:2px;"><code>()</code>, parentheses</p>
+<p style="margin-bottom:2px;"><code>#</code>, hash mark </p>
+<p style="margin-bottom:2px;"><code>+</code>, plus sign</p>
+<p style="margin-bottom:2px;"><code>-</code>, minus sign (hyphen)</p>
+<p style="margin-bottom:2px;"><code>.</code>, period </p>
+<p style="margin-bottom:2px;"><code>!</code>, exclamation mark</p>
+<p style="margin-bottom:2px;"><code>*</code>, asterisk</p>
+</td>
+<td>
+<p>Some examples on inserting special characters:</p>
+
+<p>Enter <code>&#92;&#92;</code> to get \ </p>
+<p>Enter <code>&#92;&#95;</code> to get &#95; </p>
+<p>Enter <code>&#92;# </code> to get # </p>
+<p>Enter <code>&#92;(</code> to get ( </p> 
+<p>Enter <code>&#92;.</code> to get . </p>
+<p>Enter <code>&#92;!</code> to get ! </p>
+<p>Enter <code>&#92;*</code> to get * </p>
+
+</td>
+</tr>
+</tbody>
+</table>
+
+
+## Mathematical notation and characters
+
+#### Supported in: Pull Requests | Wikis
+
+Both inline and block [KaTeX](https://khan.github.io/KaTeX/function-support.html) notation is supported in wiki pages and pull requests. The following supported elements are included:
+
+- Symbols
+- Greek letters
+- Mathematical operators
+- Powers and indices
+- Fractions and binomials
+- Other KaTeX supported elements
+
+To include mathematical notation, surround the mathematical notation with a `$` sign, for inline, and `$$` for block,  as shown in the following examples:
+
+
+> This feature is supported within Wiki pages and pull requests for TFS 2018.2 or later versions.
+
+
+### Example: Greek characters
+
+```KaTeX
+$
+\alpha, \beta, \gamma, \delta, \epsilon, \zeta, \eta, \theta, \kappa, \lambda, \mu, \nu, \omicron, \pi, \rho, \sigma, \tau, \upsilon, \phi, ...
+$  
+
+
+$\Gamma,  \Delta,  \Theta, \Lambda, \Xi, \Pi, \Sigma, \Upsilon, \Phi, \Psi, \Omega$
+```
+
+**Result:**
+
+$
+\alpha, \beta, \gamma, \delta, \epsilon, \zeta, \eta, \theta, \kappa, \lambda, \mu, \nu, \omicron, \pi, \rho, \sigma, \tau, \upsilon, \phi, ...
+$  
+
+
+$\Gamma,  \Delta,  \Theta, \Lambda, \Xi, \Pi, \Sigma, \Upsilon, \Phi, \Psi, \Omega$
+
+### Example: Algebraic notation
+
+```KaTeX
+Area of a circle is $\pi r^2$
+
+And, the area of a triangle is:
+
+$$
+A_{triangle}=\frac{1}{2}({b}\cdot{h})
+$$
+```
+
+**Result:**
+
+Area of a circle is $\pi r^2$
+
+And, the area of a triangle is:
+
+$$
+A_{triangle}=\frac{1}{2}({b}\cdot{h})
+$$
+### Example: Sums and Integrals
+
+```KaTeX
+$$
+\sum_{i=1}^{10} t_i
+$$
+
+
+$$
+\int_0^\infty \mathrm{e}^{-x}\,\mathrm{d}x
+$$     
+```
+
+**Result:**
+
+$$
+\sum_{i=1}^{10} t_i
+$$
+
+
+$$
+\int_0^\infty \mathrm{e}^{-x}\,\mathrm{d}x
+$$ 
+
+# Additional
+
+I tried to recreate the [Microsoft Docs Alerts](https://docs.microsoft.com/en-us/contribute/markdown-reference#selectors)
+They need additional styling. Might be best to somehow implement custom markdown tags. Then you can improve by adding HTML to get an example like this:
+[Improved alerts](/learn)
+
+This one needs a red background
+
+| :x: **CAUTION**  |
+|:----|
+| There will be irreversible consequences|
+
+This one needs a yellow background
+
+| :warning: **WARNING**  |
+|:----|
+| Dangerous certain consequences of an action can apply|
+
+This one needs a purlple background
+
+| :grey_exclamation: **Important**  |
+|:----|
+| Essential information required for success |
+
+This one needs a light blue background
+
+| :bulb: **Tip**  |
+|:----|
+| Optional information to help the user be more successful!|
+
+This one needs a green background
+
+| :pencil2: **Note**  |
+|:----|
+| Information the user should note when skimming the document! |
+
+## Resources
+
+Emoji cheat sheet: https://www.webfx.com/tools/emoji-cheat-sheet/
+
+
+
+

--- a/sampleDevOps/contents/emoji.md
+++ b/sampleDevOps/contents/emoji.md
@@ -1,0 +1,187 @@
+# Emoji
+
+This page contains all the details from the emoji cheat sheet.
+
+## Sources
+
+As described on the Microsoft Docs, basic Emoji is here.
+https://docs.microsoft.com/azure/devops/project/wiki/markdown-guidance?view=azure-devops#emoji
+
+## Full set of Emoji
+
+The following list is copied from https://www.webfx.com/tools/emoji-cheat-sheet/
+
+### People
+
+|    |    |    |    |    |
+|----|----|----|----|----|
+| :bowtie: `:bowtie:` | :smile: `:smile:` | :simple_smile: `:simple_smile:` | :laughing: `:laughing:` | :blush: `:blush:` |
+| :smiley: `:smiley:` | :relaxed: `:relaxed:` | :smirk: `:smirk:` | :heart_eyes: `:heart_eyes:` | :kissing_heart: `:kissing_heart:` |
+| :kissing_closed_eyes: `:kissing_closed_eyes:` | :flushed: `:flushed:` | :relieved: `:relieved:` | :satisfied: `:satisfied:` | :grin: `:grin:` |
+| :wink: `:wink:` | :stuck_out_tongue_winking_eye: `:stuck_out_tongue_winking_eye:` | :stuck_out_tongue_closed_eyes: `:stuck_out_tongue_closed_eyes:` | :grinning: `:grinning:` | :kissing: `:kissing:` |
+| :kissing_smiling_eyes: `:kissing_smiling_eyes:` | :stuck_out_tongue: `:stuck_out_tongue:` | :sleeping: `:sleeping:` | :worried: `:worried:` | :frowning: `:frowning:` |
+| :anguished: `:anguished:` | :open_mouth: `:open_mouth:` | :grimacing: `:grimacing:` | :confused: `:confused:` | :hushed: `:hushed:` |
+| :expressionless: `:expressionless:` | :unamused: `:unamused:` | :sweat_smile: `:sweat_smile:` | :sweat: `:sweat:` | :disappointed_relieved: `:disappointed_relieved:` |
+| :weary: `:weary:` | :pensive: `:pensive:` | :disappointed: `:disappointed:` | :confounded: `:confounded:` | :fearful: `:fearful:` |
+| :cold_sweat: `:cold_sweat:` | :persevere: `:persevere:` | :cry: `:cry:` | :sob: `:sob:` | :joy: `:joy:` |
+| :astonished: `:astonished:` | :scream: `:scream:` | :neckbeard: `:neckbeard:` | :tired_face: `:tired_face:` | :angry: `:angry:` |
+| :rage: `:rage:` | :triumph: `:triumph:` | :sleepy: `:sleepy:` | :yum: `:yum:` | :mask: `:mask:` |
+| :sunglasses: `:sunglasses:` | :dizzy_face: `:dizzy_face:` | :imp: `:imp:` | :smiling_imp: `:smiling_imp:` | :neutral_face: `:neutral_face:` |
+| :no_mouth: `:no_mouth:` | :innocent: `:innocent:` | :alien: `:alien:` | :yellow_heart: `:yellow_heart:` | :blue_heart: `:blue_heart:` |
+| :purple_heart: `:purple_heart:` | :heart: `:heart:` | :green_heart: `:green_heart:` | :broken_heart: `:broken_heart:` | :heartbeat: `:heartbeat:` |
+| :heartpulse: `:heartpulse:` | :two_hearts: `:two_hearts:` | :revolving_hearts: `:revolving_hearts:` | :cupid: `:cupid:` | :sparkling_heart: `:sparkling_heart:` |
+| :sparkles: `:sparkles:` | :star: `:star:` | :star2: `:star2:` | :dizzy: `:dizzy:` | :boom: `:boom:` |
+| :collision: `:collision:` | :anger: `:anger:` | :exclamation: `:exclamation:` | :question: `:question:` | :grey_exclamation: `:grey_exclamation:` |
+| :grey_question: `:grey_question:` | :zzz: `:zzz:` | :dash: `:dash:` | :sweat_drops: `:sweat_drops:` | :notes: `:notes:` |
+| :musical_note: `:musical_note:` | :fire: `:fire:` | :hankey: `:hankey:` | :poop: `:poop:` | :shit: `:shit:` |
+| :+1: `:+1:` | :thumbsup: `:thumbsup:` | :-1: `:-1:` | :thumbsdown: `:thumbsdown:` | :ok_hand: `:ok_hand:` |
+| :punch: `:punch:` | :facepunch: `:facepunch:` | :fist: `:fist:` | :v: `:v:` | :wave: `:wave:` |
+| :hand: `:hand:` | :raised_hand: `:raised_hand:` | :open_hands: `:open_hands:` | :point_up: `:point_up:` | :point_down: `:point_down:` |
+| :point_left: `:point_left:` | :point_right: `:point_right:` | :raised_hands: `:raised_hands:` | :pray: `:pray:` | :point_up_2: `:point_up_2:` |
+| :clap: `:clap:` | :muscle: `:muscle:` | :metal: `:metal:` | :fu: `:fu:` | :runner: `:runner:` |
+| :running: `:running:` | :couple: `:couple:` | :family: `:family:` | :two_men_holding_hands: `:two_men_holding_hands:` | :two_women_holding_hands: `:two_women_holding_hands:` |
+| :dancer: `:dancer:` | :dancers: `:dancers:` | :ok_woman: `:ok_woman:` | :no_good: `:no_good:` | :information_desk_person: `:information_desk_person:` |
+| :raising_hand: `:raising_hand:` | :bride_with_veil: `:bride_with_veil:` | :person_with_pouting_face: `:person_with_pouting_face:` | :person_frowning: `:person_frowning:` | :bow: `:bow:` |
+| :couplekiss: `:couplekiss:` | :couple_with_heart: `:couple_with_heart:` | :massage: `:massage:` | :haircut: `:haircut:` | :nail_care: `:nail_care:` |
+| :boy: `:boy:` | :girl: `:girl:` | :woman: `:woman:` | :man: `:man:` | :baby: `:baby:` |
+| :older_woman: `:older_woman:` | :older_man: `:older_man:` | :person_with_blond_hair: `:person_with_blond_hair:` | :man_with_gua_pi_mao: `:man_with_gua_pi_mao:` | :man_with_turban: `:man_with_turban:` |
+| :construction_worker: `:construction_worker:` | :cop: `:cop:` | :angel: `:angel:` | :princess: `:princess:` | :smiley_cat: `:smiley_cat:` |
+| :smile_cat: `:smile_cat:` | :heart_eyes_cat: `:heart_eyes_cat:` | :kissing_cat: `:kissing_cat:` | :smirk_cat: `:smirk_cat:` | :scream_cat: `:scream_cat:` |
+| :crying_cat_face: `:crying_cat_face:` | :joy_cat: `:joy_cat:` | :pouting_cat: `:pouting_cat:` | :japanese_ogre: `:japanese_ogre:` | :japanese_goblin: `:japanese_goblin:` |
+| :see_no_evil: `:see_no_evil:` | :hear_no_evil: `:hear_no_evil:` | :speak_no_evil: `:speak_no_evil:` | :guardsman: `:guardsman:` | :skull: `:skull:` |
+| :feet: `:feet:` | :lips: `:lips:` | :kiss: `:kiss:` | :droplet: `:droplet:` | :ear: `:ear:` |
+| :eyes: `:eyes:` | :nose: `:nose:` | :tongue: `:tongue:` | :love_letter: `:love_letter:` | :bust_in_silhouette: `:bust_in_silhouette:` |
+| :busts_in_silhouette: `:busts_in_silhouette:` | :speech_balloon: `:speech_balloon:` | :thought_balloon: `:thought_balloon:` | :feelsgood: `:feelsgood:` | :finnadie: `:finnadie:` |
+| :goberserk: `:goberserk:` | :godmode: `:godmode:` | :hurtrealbad: `:hurtrealbad:` | :rage1: `:rage1:` | :rage2: `:rage2:` |
+| :rage3: `:rage3:` | :rage4: `:rage4:` | :suspect: `:suspect:` | :trollface: `:trollface:` | |
+
+### Nature
+
+|    |    |    |    |    |
+|----|----|----|----|----|
+| :sunny: `:sunny:` | :umbrella: `:umbrella:` | :cloud: `:cloud:` | :snowflake: `:snowflake:` | :snowman: `:snowman:` |
+| :zap: `:zap:` | :cyclone: `:cyclone:` | :foggy: `:foggy:` | :ocean: `:ocean:` | :cat: `:cat:` |
+| :dog: `:dog:` | :mouse: `:mouse:` | :hamster: `:hamster:` | :rabbit: `:rabbit:` | :wolf: `:wolf:` |
+| :frog: `:frog:` | :tiger: `:tiger:` | :koala: `:koala:` | :bear: `:bear:` | :pig: `:pig:` |
+| :pig_nose: `:pig_nose:` | :cow: `:cow:` | :boar: `:boar:` | :monkey_face: `:monkey_face:` | :monkey: `:monkey:` |
+| :horse: `:horse:` | :racehorse: `:racehorse:` | :camel: `:camel:` | :sheep: `:sheep:` | :elephant: `:elephant:` |
+| :panda_face: `:panda_face:` | :snake: `:snake:` | :bird: `:bird:` | :baby_chick: `:baby_chick:` | :hatched_chick: `:hatched_chick:` |
+| :hatching_chick: `:hatching_chick:` | :chicken: `:chicken:` | :penguin: `:penguin:` | :turtle: `:turtle:` | :bug: `:bug:` |
+| :honeybee: `:honeybee:` | :ant: `:ant:` | :beetle: `:beetle:` | :snail: `:snail:` | :octopus: `:octopus:` |
+| :tropical_fish: `:tropical_fish:` | :fish: `:fish:` | :whale: `:whale:` | :whale2: `:whale2:` | :dolphin: `:dolphin:` |
+| :cow2: `:cow2:` | :ram: `:ram:` | :rat: `:rat:` | :water_buffalo: `:water_buffalo:` | :tiger2: `:tiger2:` |
+| :rabbit2: `:rabbit2:` | :dragon: `:dragon:` | :goat: `:goat:` | :rooster: `:rooster:` | :dog2: `:dog2:` |
+| :pig2: `:pig2:` | :mouse2: `:mouse2:` | :ox: `:ox:` | :dragon_face: `:dragon_face:` | :blowfish: `:blowfish:` |
+| :crocodile: `:crocodile:` | :dromedary_camel: `:dromedary_camel:` | :leopard: `:leopard:` | :cat2: `:cat2:` | :poodle: `:poodle:` |
+| :paw_prints: `:paw_prints:` | :bouquet: `:bouquet:` | :cherry_blossom: `:cherry_blossom:` | :tulip: `:tulip:` | :four_leaf_clover: `:four_leaf_clover:` |
+| :rose: `:rose:` | :sunflower: `:sunflower:` | :hibiscus: `:hibiscus:` | :maple_leaf: `:maple_leaf:` | :leaves: `:leaves:` |
+| :fallen_leaf: `:fallen_leaf:` | :herb: `:herb:` | :mushroom: `:mushroom:` | :cactus: `:cactus:` | :palm_tree: `:palm_tree:` |
+| :evergreen_tree: `:evergreen_tree:` | :deciduous_tree: `:deciduous_tree:` | :chestnut: `:chestnut:` | :seedling: `:seedling:` | :blossom: `:blossom:` |
+| :ear_of_rice: `:ear_of_rice:` | :shell: `:shell:` | :globe_with_meridians: `:globe_with_meridians:` | :sun_with_face: `:sun_with_face:` | :full_moon_with_face: `:full_moon_with_face:` |
+| :new_moon_with_face: `:new_moon_with_face:` | :new_moon: `:new_moon:` | :waxing_crescent_moon: `:waxing_crescent_moon:` | :first_quarter_moon: `:first_quarter_moon:` | :waxing_gibbous_moon: `:waxing_gibbous_moon:` |
+| :full_moon: `:full_moon:` | :waning_gibbous_moon: `:waning_gibbous_moon:` | :last_quarter_moon: `:last_quarter_moon:` | :waning_crescent_moon: `:waning_crescent_moon:` | :last_quarter_moon_with_face: `:last_quarter_moon_with_face:` |
+| :first_quarter_moon_with_face: `:first_quarter_moon_with_face:` | :crescent_moon: `:crescent_moon:` | :earth_africa: `:earth_africa:` | :earth_americas: `:earth_americas:` | :earth_asia: `:earth_asia:` |
+| :volcano: `:volcano:` | :milky_way: `:milky_way:` | :partly_sunny: `:partly_sunny:` | :octocat: `:octocat:` | :squirrel: `:squirrel:` |
+
+### Objects
+
+|    |    |    |    |    |
+|----|----|----|----|----|
+| :bamboo: `:bamboo:` | :gift_heart: `:gift_heart:` | :dolls: `:dolls:` | :school_satchel: `:school_satchel:` | :mortar_board: `:mortar_board:` |
+| :flags: `:flags:` | :fireworks: `:fireworks:` | :sparkler: `:sparkler:` | :wind_chime: `:wind_chime:` | :rice_scene: `:rice_scene:` |
+| :jack_o_lantern: `:jack_o_lantern:` | :ghost: `:ghost:` | :santa: `:santa:` | :christmas_tree: `:christmas_tree:` | :gift: `:gift:` |
+| :bell: `:bell:` | :no_bell: `:no_bell:` | :tanabata_tree: `:tanabata_tree:` | :tada: `:tada:` | :confetti_ball: `:confetti_ball:` |
+| :balloon: `:balloon:` | :crystal_ball: `:crystal_ball:` | :cd: `:cd:` | :dvd: `:dvd:` | :floppy_disk: `:floppy_disk:` |
+| :camera: `:camera:` | :video_camera: `:video_camera:` | :movie_camera: `:movie_camera:` | :computer: `:computer:` | :tv: `:tv:` |
+| :iphone: `:iphone:` | :phone: `:phone:` | :telephone: `:telephone:` | :telephone_receiver: `:telephone_receiver:` | :pager: `:pager:` |
+| :fax: `:fax:` | :minidisc: `:minidisc:` | :vhs: `:vhs:` | :sound: `:sound:` | :speaker: `:speaker:` |
+| :mute: `:mute:` | :loudspeaker: `:loudspeaker:` | :mega: `:mega:` | :hourglass: `:hourglass:` | :hourglass_flowing_sand: `:hourglass_flowing_sand:` |
+| :alarm_clock: `:alarm_clock:` | :watch: `:watch:` | :radio: `:radio:` | :satellite: `:satellite:` | :loop: `:loop:` |
+| :mag: `:mag:` | :mag_right: `:mag_right:` | :unlock: `:unlock:` | :lock: `:lock:` | :lock_with_ink_pen: `:lock_with_ink_pen:` |
+| :closed_lock_with_key: `:closed_lock_with_key:` | :key: `:key:` | :bulb: `:bulb:` | :flashlight: `:flashlight:` | :high_brightness: `:high_brightness:` |
+| :low_brightness: `:low_brightness:` | :electric_plug: `:electric_plug:` | :battery: `:battery:` | :calling: `:calling:` | :email: `:email:` |
+| :mailbox: `:mailbox:` | :postbox: `:postbox:` | :bath: `:bath:` | :bathtub: `:bathtub:` | :shower: `:shower:` |
+| :toilet: `:toilet:` | :wrench: `:wrench:` | :nut_and_bolt: `:nut_and_bolt:` | :hammer: `:hammer:` | :seat: `:seat:` |
+| :moneybag: `:moneybag:` | :yen: `:yen:` | :dollar: `:dollar:` | :pound: `:pound:` | :euro: `:euro:` |
+| :credit_card: `:credit_card:` | :money_with_wings: `:money_with_wings:` | :e-mail: `:e-mail:` | :inbox_tray: `:inbox_tray:` | :outbox_tray: `:outbox_tray:` |
+| :envelope: `:envelope:` | :incoming_envelope: `:incoming_envelope:` | :postal_horn: `:postal_horn:` | :mailbox_closed: `:mailbox_closed:` | :mailbox_with_mail: `:mailbox_with_mail:` |
+| :mailbox_with_no_mail: `:mailbox_with_no_mail:` | :package: `:package:` | :door: `:door:` | :smoking: `:smoking:` | :bomb: `:bomb:` |
+| :gun: `:gun:` | :hocho: `:hocho:` | :pill: `:pill:` | :syringe: `:syringe:` | :page_facing_up: `:page_facing_up:` |
+| :page_with_curl: `:page_with_curl:` | :bookmark_tabs: `:bookmark_tabs:` | :bar_chart: `:bar_chart:` | :chart_with_upwards_trend: `:chart_with_upwards_trend:` | :chart_with_downwards_trend: `:chart_with_downwards_trend:` |
+| :scroll: `:scroll:` | :clipboard: `:clipboard:` | :calendar: `:calendar:` | :date: `:date:` | :card_index: `:card_index:` |
+| :file_folder: `:file_folder:` | :open_file_folder: `:open_file_folder:` | :scissors: `:scissors:` | :pushpin: `:pushpin:` | :paperclip: `:paperclip:` |
+| :black_nib: `:black_nib:` | :pencil2: `:pencil2:` | :straight_ruler: `:straight_ruler:` | :triangular_ruler: `:triangular_ruler:` | :closed_book: `:closed_book:` |
+| :green_book: `:green_book:` | :blue_book: `:blue_book:` | :orange_book: `:orange_book:` | :notebook: `:notebook:` | :notebook_with_decorative_cover: `:notebook_with_decorative_cover:` |
+| :ledger: `:ledger:` | :books: `:books:` | :bookmark: `:bookmark:` | :name_badge: `:name_badge:` | :microscope: `:microscope:` |
+| :telescope: `:telescope:` | :newspaper: `:newspaper:` | :football: `:football:` | :basketball: `:basketball:` | :soccer: `:soccer:` |
+| :baseball: `:baseball:` | :tennis: `:tennis:` | :8ball: `:8ball:` | :rugby_football: `:rugby_football:` | :bowling: `:bowling:` |
+| :golf: `:golf:` | :mountain_bicyclist: `:mountain_bicyclist:` | :bicyclist: `:bicyclist:` | :horse_racing: `:horse_racing:` | :snowboarder: `:snowboarder:` |
+| :swimmer: `:swimmer:` | :surfer: `:surfer:` | :ski: `:ski:` | :spades: `:spades:` | :hearts: `:hearts:` |
+| :clubs: `:clubs:` | :diamonds: `:diamonds:` | :gem: `:gem:` | :ring: `:ring:` | :trophy: `:trophy:` |
+| :musical_score: `:musical_score:` | :musical_keyboard: `:musical_keyboard:` | :violin: `:violin:` | :space_invader: `:space_invader:` | :video_game: `:video_game:` |
+| :black_joker: `:black_joker:` | :flower_playing_cards: `:flower_playing_cards:` | :game_die: `:game_die:` | :dart: `:dart:` | :mahjong: `:mahjong:` |
+| :clapper: `:clapper:` | :memo: `:memo:` | :pencil: `:pencil:` | :book: `:book:` | :art: `:art:` |
+| :microphone: `:microphone:` | :headphones: `:headphones:` | :trumpet: `:trumpet:` | :saxophone: `:saxophone:` | :guitar: `:guitar:` |
+| :shoe: `:shoe:` | :sandal: `:sandal:` | :high_heel: `:high_heel:` | :lipstick: `:lipstick:` | :boot: `:boot:` |
+| :shirt: `:shirt:` | :tshirt: `:tshirt:` | :necktie: `:necktie:` | :womans_clothes: `:womans_clothes:` | :dress: `:dress:` |
+| :running_shirt_with_sash: `:running_shirt_with_sash:` | :jeans: `:jeans:` | :kimono: `:kimono:` | :bikini: `:bikini:` | :ribbon: `:ribbon:` |
+| :tophat: `:tophat:` | :crown: `:crown:` | :womans_hat: `:womans_hat:` | :mans_shoe: `:mans_shoe:` | :closed_umbrella: `:closed_umbrella:` |
+| :briefcase: `:briefcase:` | :handbag: `:handbag:` | :pouch: `:pouch:` | :purse: `:purse:` | :eyeglasses: `:eyeglasses:` |
+| :fishing_pole_and_fish: `:fishing_pole_and_fish:` | :coffee: `:coffee:` | :tea: `:tea:` | :sake: `:sake:` | :baby_bottle: `:baby_bottle:` |
+| :beer: `:beer:` | :beers: `:beers:` | :cocktail: `:cocktail:` | :tropical_drink: `:tropical_drink:` | :wine_glass: `:wine_glass:` |
+| :fork_and_knife: `:fork_and_knife:` | :pizza: `:pizza:` | :hamburger: `:hamburger:` | :fries: `:fries:` | :poultry_leg: `:poultry_leg:` |
+| :meat_on_bone: `:meat_on_bone:` | :spaghetti: `:spaghetti:` | :curry: `:curry:` | :fried_shrimp: `:fried_shrimp:` | :bento: `:bento:` |
+| :sushi: `:sushi:` | :fish_cake: `:fish_cake:` | :rice_ball: `:rice_ball:` | :rice_cracker: `:rice_cracker:` | :rice: `:rice:` |
+| :ramen: `:ramen:` | :stew: `:stew:` | :oden: `:oden:` | :dango: `:dango:` | :egg: `:egg:` |
+| :bread: `:bread:` | :doughnut: `:doughnut:` | :custard: `:custard:` | :icecream: `:icecream:` | :ice_cream: `:ice_cream:` |
+| :shaved_ice: `:shaved_ice:` | :birthday: `:birthday:` | :cake: `:cake:` | :cookie: `:cookie:` | :chocolate_bar: `:chocolate_bar:` |
+| :candy: `:candy:` | :lollipop: `:lollipop:` | :honey_pot: `:honey_pot:` | :apple: `:apple:` | :green_apple: `:green_apple:` |
+| :tangerine: `:tangerine:` | :lemon: `:lemon:` | :cherries: `:cherries:` | :grapes: `:grapes:` | :watermelon: `:watermelon:` |
+| :strawberry: `:strawberry:` | :peach: `:peach:` | :melon: `:melon:` | :banana: `:banana:` | :pear: `:pear:` |
+| :pineapple: `:pineapple:` | :sweet_potato: `:sweet_potato:` | :eggplant: `:eggplant:` | :tomato: `:tomato:` | :corn: `:corn:` |
+
+### Places
+
+|    |    |    |    |    |
+|----|----|----|----|----|
+| :house: `:house:` | :house_with_garden: `:house_with_garden:` | :school: `:school:` | :office: `:office:` | :post_office: `:post_office:` |
+| :hospital: `:hospital:` | :bank: `:bank:` | :convenience_store: `:convenience_store:` | :love_hotel: `:love_hotel:` | :hotel: `:hotel:` |
+| :wedding: `:wedding:` | :church: `:church:` | :department_store: `:department_store:` | :european_post_office: `:european_post_office:` | :city_sunrise: `:city_sunrise:` |
+| :city_sunset: `:city_sunset:` | :japanese_castle: `:japanese_castle:` | :european_castle: `:european_castle:` | :tent: `:tent:` | :factory: `:factory:` |
+| :tokyo_tower: `:tokyo_tower:` | :japan: `:japan:` | :mount_fuji: `:mount_fuji:` | :sunrise_over_mountains: `:sunrise_over_mountains:` | :sunrise: `:sunrise:` |
+| :stars: `:stars:` | :statue_of_liberty: `:statue_of_liberty:` | :bridge_at_night: `:bridge_at_night:` | :carousel_horse: `:carousel_horse:` | :rainbow: `:rainbow:` |
+| :ferris_wheel: `:ferris_wheel:` | :fountain: `:fountain:` | :roller_coaster: `:roller_coaster:` | :ship: `:ship:` | :speedboat: `:speedboat:` |
+| :boat: `:boat:` | :sailboat: `:sailboat:` | :rowboat: `:rowboat:` | :anchor: `:anchor:` | :rocket: `:rocket:` |
+| :airplane: `:airplane:` | :helicopter: `:helicopter:` | :steam_locomotive: `:steam_locomotive:` | :tram: `:tram:` | :mountain_railway: `:mountain_railway:` |
+| :bike: `:bike:` | :aerial_tramway: `:aerial_tramway:` | :suspension_railway: `:suspension_railway:` | :mountain_cableway: `:mountain_cableway:` | :tractor: `:tractor:` |
+| :blue_car: `:blue_car:` | :oncoming_automobile: `:oncoming_automobile:` | :car: `:car:` | :red_car: `:red_car:` | :taxi: `:taxi:` |
+| :oncoming_taxi: `:oncoming_taxi:` | :articulated_lorry: `:articulated_lorry:` | :bus: `:bus:` | :oncoming_bus: `:oncoming_bus:` | :rotating_light: `:rotating_light:` |
+| :police_car: `:police_car:` | :oncoming_police_car: `:oncoming_police_car:` | :fire_engine: `:fire_engine:` | :ambulance: `:ambulance:` | :minibus: `:minibus:` |
+| :truck: `:truck:` | :train: `:train:` | :station: `:station:` | :train2: `:train2:` | :bullettrain_front: `:bullettrain_front:` |
+| :bullettrain_side: `:bullettrain_side:` | :light_rail: `:light_rail:` | :monorail: `:monorail:` | :railway_car: `:railway_car:` | :trolleybus: `:trolleybus:` |
+| :ticket: `:ticket:` | :fuelpump: `:fuelpump:` | :vertical_traffic_light: `:vertical_traffic_light:` | :traffic_light: `:traffic_light:` | :warning: `:warning:` |
+| :construction: `:construction:` | :beginner: `:beginner:` | :atm: `:atm:` | :slot_machine: `:slot_machine:` | :busstop: `:busstop:` |
+| :barber: `:barber:` | :hotsprings: `:hotsprings:` | :checkered_flag: `:checkered_flag:` | :crossed_flags: `:crossed_flags:` | :izakaya_lantern: `:izakaya_lantern:` |
+| :moyai: `:moyai:` | :circus_tent: `:circus_tent:` | :performing_arts: `:performing_arts:` | :round_pushpin: `:round_pushpin:` | :triangular_flag_on_post: `:triangular_flag_on_post:` |
+| :jp: `:jp:` | :kr: `:kr:` | :cn: `:cn:` | :us: `:us:` | :fr: `:fr:` |
+| :es: `:es:` | :it: `:it:` | :ru: `:ru:` | :gb: `:gb:` | :uk: `:uk:` |
+| :de: `:de:` | | | | |
+
+### Symbols
+
+|    |    |    |    |    |
+|----|----|----|----|----|
+| :soon: `:soon:` | :clock1: `:clock1:` | :clock130: `:clock130:` | :clock10: `:clock10:` | :clock1030: `:clock1030:` |
+| :clock11: `:clock11:` | :clock1130: `:clock1130:` | :clock12: `:clock12:` | :clock1230: `:clock1230:` | :clock2: `:clock2:` |
+| :clock230: `:clock230:` | :clock3: `:clock3:` | :clock330: `:clock330:` | :clock4: `:clock4:` | :clock430: `:clock430:` |
+| :clock5: `:clock5:` | :clock530: `:clock530:` | :clock6: `:clock6:` | :clock630: `:clock630:` | :clock7: `:clock7:` |
+| :clock730: `:clock730:` | :clock8: `:clock8:` | :clock830: `:clock830:` | :clock9: `:clock9:` | :clock930: `:clock930:` |
+| :heavy_dollar_sign: `:heavy_dollar_sign:` | :copyright: `:copyright:` | :registered: `:registered:` | :tm: `:tm:` | :x: `:x:` |
+| :heavy_exclamation_mark: `:heavy_exclamation_mark:` | :bangbang: `:bangbang:` | :interrobang: `:interrobang:` | :o: `:o:` | :heavy_multiplication_x: `:heavy_multiplication_x:` |
+| :heavy_plus_sign: `:heavy_plus_sign:` | :heavy_minus_sign: `:heavy_minus_sign:` | :heavy_division_sign: `:heavy_division_sign:` | :white_flower: `:white_flower:` | :100: `:100:` |
+| :heavy_check_mark: `:heavy_check_mark:` | :ballot_box_with_check: `:ballot_box_with_check:` | :radio_button: `:radio_button:` | :link: `:link:` | :curly_loop: `:curly_loop:` |
+| :wavy_dash: `:wavy_dash:` | :part_alternation_mark: `:part_alternation_mark:` | :trident: `:trident:` | :black_small_square: `:black_small_square:` | :white_small_square: `:white_small_square:` |
+| :black_medium_small_square: `:black_medium_small_square:` | :white_medium_small_square: `:white_medium_small_square:` | :black_medium_square: `:black_medium_square:` | :white_medium_square: `:white_medium_square:` | :black_large_square: `:black_large_square:` |
+| :white_large_square: `:white_large_square:` | :white_check_mark: `:white_check_mark:` | :black_square_button: `:black_square_button:` | :white_square_button: `:white_square_button:` | :black_circle: `:black_circle:` |
+| :white_circle: `:white_circle:` | :red_circle: `:red_circle:` | :large_blue_circle: `:large_blue_circle:` | :large_blue_diamond: `:large_blue_diamond:` | :large_orange_diamond: `:large_orange_diamond:` |
+| :small_blue_diamond: `:small_blue_diamond:` | :small_orange_diamond: `:small_orange_diamond:` | :small_red_triangle: `:small_red_triangle:` | :small_red_triangle_down: `:small_red_triangle_down:` | :shipit: `:shipit:` |

--- a/sampleDevOps/contents/placeholder.md
+++ b/sampleDevOps/contents/placeholder.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Placeholder
+subtitle: Simple page with a comment section 
+summary: this meta section should not be rendered
+order: 1 
+tags: placeholder, meta
+---
+
+# Placeholder
+
+This is just a page with a single header and this single line of text. Use this to see if page breaks work.
+This page also features a markdown comment block, that should not be rendered.

--- a/sampleDevOps/devopswikistyle.css
+++ b/sampleDevOps/devopswikistyle.css
@@ -1,0 +1,338 @@
+/* this style guide will mimic the behaviour of various markdown as in Azure Dev Ops */
+body, html {
+    color: #191919;
+    word-wrap: break-word;
+    font-family: Segoe UI,SegoeUI,Helvetica Neue,Helvetica,Arial,sans-serif;
+    font-size: .9375rem
+}
+
+html >*:first-child {
+    margin-top: 0
+}
+
+html >*:last-child {
+    margin-bottom: 0
+}
+
+ a {
+    color: #005a9e;
+    text-decoration: none;
+    outline: transparent
+}
+
+ a:hover {
+    color: #004578;
+}
+
+ p,
+ blockquote,
+ ul,
+ ol,
+ table,
+ pre {
+    margin: 0 0 16px 0
+}
+
+ table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    color: #191919;
+    cursor: default;
+    display: block;
+    overflow-x: auto;
+    font-size: .9375rem;
+}
+
+ table table {
+    margin-bottom: 0
+}
+
+ table th {
+    color: #737373;
+    font-size: .9375rem;
+    font-weight: 600;
+    text-align: left;
+    border: 1px solid #eaeaea;
+    padding: 13px 11px
+}
+
+ table td {
+    border: 1px solid #eaeaea;
+    text-align: left;
+    padding: 10px 13px;
+    min-width: 50px;
+    max-width: 1000px
+}
+
+ code {
+    font-family: Menlo, Consolas, Courier New, monospace;
+    font-size: .75rem;
+    background-color: #f0f0f0;
+    color: #191919;
+    padding: 2px 4px;
+    border-radius: 2px
+}
+
+ hr {
+    border: 1px solid #eaeaea;
+}
+
+ pre {
+    font-size: .75rem;
+    white-space: pre;
+    word-wrap: normal;
+    background-color: #f0f0f0;
+    border-radius: 2px;
+    padding: 15px;
+    overflow-x: auto
+}
+
+ pre code {
+    font-size: inherit;
+    background-color: transparent;
+    padding: 0
+}
+
+ blockquote {
+    color: #4d4d4d;
+    border-left: 2px solid #eaeaea;
+    padding-left: 16px
+}
+
+ blockquote>*:first-child {
+    margin-top: 0
+}
+
+ blockquote>*:last-child {
+    margin-bottom: 0
+}
+
+ blockquote>p,
+ blockquote ol,
+ blockquote ul {
+    margin: 16px 0
+}
+
+ img {
+    max-width: 100%
+}
+
+ ul,
+ ol {
+    padding-left: 32px
+}
+
+ ul ul,
+ ul ol,
+ ol ul,
+ ol ol {
+    margin-top: 0;
+    margin-bottom: 0
+}
+
+ li {
+    list-style: inherit
+}
+
+ li+li {
+    margin-top: 4px
+}
+
+ h1 {
+    font-size: 1.3125rem;
+    font-weight: 600;
+    color: #191919;
+    margin: 24px 0 8px 0;
+    letter-spacing: -.04em
+}
+
+ h1 .bowtie-icon {
+    font-size: unset
+}
+
+ h1:first-child {
+    margin-top: 0
+}
+
+ h2 {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    color: #191919;
+    margin: 24px 0 8px 0
+}
+
+ h2 .bowtie-icon {
+    font-size: unset
+}
+
+ h3 {
+    font-size: .9375rem;
+    font-weight: 600;
+    color: #191919;
+    margin: 24px 0 8px 0
+}
+
+ h3 .bowtie-icon {
+    font-size: unset
+}
+
+ h4 {
+    font-size: .875rem;
+    font-weight: 600;
+    color: #191919;
+    margin: 24px 0 8px 0
+}
+
+ h4 .bowtie-icon {
+    font-size: unset
+}
+
+ h5 {
+    font-size: .75rem;
+    font-weight: 600;
+    color: #191919;
+    margin: 24px 0 8px 0
+}
+
+ h5 .bowtie-icon {
+    font-size: unset
+}
+
+ h6 {
+    font-size: .75rem;
+    font-weight: 600;
+    color: #737373;
+    margin: 24px 0 8px 0
+}
+
+ h6 .bowtie-icon {
+    font-size: unset
+}
+
+.bolt-focus-visible  a:focus {
+    outline: #666666 solid 1px;
+}
+
+.hljs {
+    display: block;
+    overflow-x: auto;
+    padding: .5em;
+    color: #191919;
+    -webkit-text-size-adjust: none
+}
+
+.markdown-preview-container {
+    margin: 20px
+}
+
+table.metadata-yaml-table {
+    font-size: .75rem;
+    line-height: 1
+}
+
+.toc-container {
+    border: 1px solid;
+    border-color: #eaeaea;
+    border-radius: 4px;
+    display: inline-block;
+    padding: 10px 16px 10px 0;
+    margin-bottom: 14px;
+    min-width: 250px
+}
+
+.toc-container .toc-container-header {
+    font-weight: 600;
+    margin: 0 16px 5px 16px
+}
+
+.toc-container ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 16px;
+    color: #005a9e;
+}
+
+.toc-container ul li {
+    margin-top: 4px;
+    margin-bottom: 0
+}
+
+.toc-container li::before {
+    content: "\2022 "
+}
+
+.toc-container a {
+    margin-left: 5px;
+    display: inline-block;
+    vertical-align: top;
+    width: auto;
+    max-width: 400px;
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    word-wrap: normal
+}
+
+.task-list input.task-list-item-checkbox {
+    vertical-align: middle;
+    margin: 4px;
+    float: none
+}
+
+ul li.task-list-item {
+    list-style-type: none
+}
+
+ul.task-list {
+    padding-left: 7px
+}
+
+li.task-list-item {
+    min-height: 18px
+}
+
+/* additional styling */
+
+div.is-note table {
+    background-color: #E2DAF1; /* hsl(262deg 46% 90%); */
+    border-radius:6px;
+    -moz-border-radius:6px;
+    border: none;
+    font-size: inherit;
+}
+div.is-tip table {
+    background-color: #D2F9D2; /* hsl(120deg 77% 90%); */
+    border-radius:6px;
+    -moz-border-radius:6px;
+    border: none;
+    font-size: inherit;
+}
+div.is-important table {
+    background-color:  #E0F2FF; /*hsl(205deg 100% 94%); */
+    border-radius:6px;
+    -moz-border-radius:6px;
+    border: none;
+    font-size: inherit;
+}
+div.is-caution table {
+    background-color: #FFDACC; /* hsl(16deg 100% 90%); */
+    border-radius:6px;
+    -moz-border-radius:6px;
+    border: none;
+    font-size: inherit;
+}
+div.is-warning table {
+    background-color: #FFF1CC; /* hsl(44deg 100% 90%); */
+    border-radius:6px;
+    -moz-border-radius:6px;
+    border: none;
+    font-size: inherit;
+}
+div.is-note th, div.is-note td,div.is-tip th, div.is-tip td,
+div.is-important th,div.is-important td,div.is-caution th,
+div.is-caution td,div.is-warning th, div.is-warning td {
+    border: none;
+}
+
+

--- a/sampleDevOps/learn.md
+++ b/sampleDevOps/learn.md
@@ -1,0 +1,95 @@
+# How to learn
+
+Here are a few recources
+
+* https://docs.microsoft.com/en-us/azure/devops/project/wiki/publish-repo-to-wiki?view=azure-devops&tabs=browser
+
+## Markdown examples
+
+## Text
+
+**bold**, _italic_, ~~strickthrough~~, <u>underline using html</u>
+
+> blockqote example
+
+above a line
+
+----
+under the line
+
+`Single line of code`
+
+``` js
+print("block of code");
+```
+
+
+|table| header1 | column |
+|----|----|----|
+|cell  |cell  |cell  |
+|cell  |cell  |cell  |
+
+
+## Mermaid diagram
+
+::: mermaid
+ graph LR;
+ A[Wiki supports Mermaid] --> B[Visit https://mermaidjs.github.io/ for Mermaid syntax];
+:::
+
+## pointers
+
+This one needs a red background
+
+<div class="is-caution">
+
+| :x: **CAUTION**  |
+|:----|
+| There will be irreversible consequences|
+</div>
+
+This one needs a yellow background
+
+<div class="is-warning">
+
+| :warning: **WARNING**  |
+|:----|
+| Dangerous certain consequences of an action can apply|
+</div>
+
+This one needs a purlple background
+
+<div class="is-important">
+
+| :grey_exclamation: **Important**  |
+|:----|
+| Essential information required for success |
+</div>
+
+This one needs a light blue background
+
+<div class="is-tip">
+
+| :bulb: **Tip**  |
+|:----|
+| Optional information to help the user be more successful!|
+</div>
+
+This one needs a green background
+
+<div class="is-note">
+
+| :pencil2: **Note**  |
+|:----|
+| Information the user should note when skimming the document! |
+</div>
+
+## Shorthand
+
+Here is an example of how to render a PDF from the command line.
+
+```
+ .\azuredevops-export-wiki.exe -v --debug --css .\style.css --header-url .\header.html --footer-url .\footer.html
+```
+
+


### PR DESCRIPTION
Hi Max,

Here is the test case that I created. At the moment it does a little more then PDF export supports, but that might just be fun, to have this as a reference if functionality is getting better.

The test with markdown contains most of the examples in https://docs.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops

There are few issues to report:
- headers are rendered incorrectly (H1 is not a H1 tag, and so on...)
- Tables still look odd to my eyes (probably in the styling)
- Emojis behave very weird. Only a few work, and most display empty characters (or two)

Let me know if I need to organize this differently. 