### PR TITLE
Display work item link using AzDevops API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,6 +43,8 @@
                 //"-m"
                 //"--filter=tags:test,tags:license"
                 // "-c"
+                // "--organization=https://dev.azure.com/mmelcher",
+                // "--pat=xxx"
             ],
             "cwd": "${workspaceFolder}/AzureDevOps.WikiPDFExport",
             "console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
                 //"--filter=tags:test,tags:license"
                 // "-c"
                 // "--organization=https://dev.azure.com/mmelcher",
-                // "--pat=xxx"
+                // "--pat=e3jbikqf33tucikgqwznlbi263hxjsw5nlstb2n2fzvcmtrw5tuq" #Read issues, valid until August 2022
             ],
             "cwd": "${workspaceFolder}/AzureDevOps.WikiPDFExport",
             "console": "internalConsole",

--- a/AzureDevOps.WikiPDFExport.Test/Tests/Code/Admin-Layout-and-Customization.md
+++ b/AzureDevOps.WikiPDFExport.Test/Tests/Code/Admin-Layout-and-Customization.md
@@ -164,3 +164,17 @@ Following variables are included in the above partial view:
 | ```<input type="hidden" id="ConfirmClearLoginHistoryText" value="@Messages.ConfirmClearLoginHistoryText" />``` | Messages.ConfirmClearLoginHistoryText | Messages.resx | Are you sure to clear Login History? |
 | ```<input type="hidden" id="MissingRequiredFields" value="@Messages.MissingRequiredFields" />``` | Messages.MissingRequiredFields | Messages.resx | Validation Failed, Please Provide Required Fields |
   
+## Azure Devops Work Item link
+
+#7
+
+* Working link in list
+* #8
+
+Working link between #7 text
+
+#NotAWorkItemId
+
+Non working link#7
+#7Non working link
+Definitly#7Non working link

--- a/AzureDevOps.WikiPDFExport.Test/Tests/Code/Admin-Layout-and-Customization.md
+++ b/AzureDevOps.WikiPDFExport.Test/Tests/Code/Admin-Layout-and-Customization.md
@@ -173,6 +173,8 @@ Following variables are included in the above partial view:
 
 Working link between #7 text
 
+#6 - A bug
+
 #NotAWorkItemId
 
 Non working link#7

--- a/AzureDevOps.WikiPDFExport/Program.cs
+++ b/AzureDevOps.WikiPDFExport/Program.cs
@@ -102,5 +102,11 @@ namespace azuredevops_export_wiki
 
         [Option("hightlight-style", Required = false, HelpText = "hightlight.js style used for code blocks. Defaults to 'vs'. See https://github.com/highlightjs/highlight.js/tree/main/src/styles for a full list.")]
         public string HighlightStyle { get;set; }
+
+        [Option("pat", Required = false, HelpText = "Personal access token used to access your Azure Devops Organization. If no token is provided and organization and project parameters are provided, it will start a prompt asking you to login.")]
+        public string AzureDevopsPAT { get;set; }
+
+        [Option("organization", Required = false, HelpText = "Azure Devops organization URL used to convert work item references to work item links. Ex: https://dev.azure.com/MyOrganizationName/")]
+        public string AzureDevopsOrganization { get;set; }
     }
 }

--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -23,6 +23,13 @@ using azuredevops_export_wiki.MermaidContainer;
 using Markdig.Parsers;
 using Markdig.Extensions.Yaml;
 using Markdig.Helpers;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.Client;
+using Microsoft.VisualStudio.Services.Common;
+
+using Microsoft.VisualStudio.Services.WebApi;
+using Process = System.Diagnostics.Process;
 
 namespace azuredevops_export_wiki
 {
@@ -31,6 +38,7 @@ namespace azuredevops_export_wiki
         private Options _options;
         private TelemetryClient _telemetryClient;
         private string _path;
+        private Dictionary<string, string> _iconClass;
 
         public WikiPDFExporter(Options options)
         {
@@ -46,6 +54,51 @@ namespace azuredevops_export_wiki
             }
             _telemetryClient = new TelemetryClient(config);
 
+            this._iconClass = new Dictionary<string, string>(){
+                {"icon_crown", "bowtie-symbol-crown"},
+                {"icon_trophy", "bowtie-symbol-trophy"},
+                {"icon_list", "bowtie-symbol-list"},
+                {"icon_book", "bowtie-symbol-book"},
+                {"icon_sticky_note", "bowtie-symbol-stickynote"},
+                {"icon_clipboard", "bowtie-symbol-task"},
+                {"icon_insect", "bowtie-symbol-bug"},
+                {"icon_traffic_cone", "bowtie-symbol-impediment"},
+                {"icon_chat_bubble", "bowtie-symbol-review"},
+                {"icon_flame", "bowtie-symbol-flame"},
+                {"icon_megaphone", "bowtie-symbol-ask"},
+                {"icon_test_plan", "bowtie-test-plan"},
+                {"icon_test_suite", "bowtie-test-suite"},
+                {"icon_test_case", "bowtie-test-case"},
+                {"icon_test_step", "bowtie-test-step"},
+                {"icon_test_parameter", "bowtie-test-parameter"},
+                {"icon_code_review", "bowtie-symbol-review-request"},
+                {"icon_code_response", "bowtie-symbol-review-response"},
+                {"icon_review", "bowtie-symbol-feedback-request"},
+                {"icon_response", "bowtie-symbol-feedback-response"},
+                {"icon_ribbon", "bowtie-symbol-ribbon"},
+                {"icon_chart", "bowtie-symbol-finance"},
+                {"icon_headphone", "bowtie-symbol-headphone"},
+                {"icon_key", "bowtie-symbol-key"},
+                {"icon_airplane", "bowtie-symbol-airplane"},
+                {"icon_car", "bowtie-symbol-car"},
+                {"icon_diamond", "bowtie-symbol-diamond"},
+                {"icon_asterisk", "bowtie-symbol-asterisk"},
+                {"icon_database_storage", "bowtie-symbol-storage-database"},
+                {"icon_government", "bowtie-symbol-government"},
+                {"icon_gavel", "bowtie-symbol-decision"},
+                {"icon_parachute", "bowtie-symbol-parachute"},
+                {"icon_paint_brush", "bowtie-symbol-paint-brush"},
+                {"icon_palette", "bowtie-symbol-color-palette"},
+                {"icon_gear", "bowtie-settings-gear"},
+                {"icon_check_box", "bowtie-status-success-box"},
+                {"icon_gift", "bowtie-package-fill"},
+                {"icon_test_beaker", "bowtie-test-fill"},
+                {"icon_broken_lightbulb", "bowtie-symbol-defect"},
+                {"icon_clipboard_issue", "bowtie-symbol-issue"},
+                {"icon_github", "bowtie-brand-github"},
+                {"icon_pull_request", "bowtie-tfvc-pull-request"},
+                {"icon_github_issue", "bowtie-status-error-outline"},
+            };
 
         }
 
@@ -194,6 +247,22 @@ namespace azuredevops_export_wiki
                             await page.SetContentAsync(html);
                             html = await page.GetContentAsync();
                         }
+                    }
+
+                    if (_options.AzureDevopsOrganization != null)
+                    {
+                        VssCredentials credentials = !string.IsNullOrEmpty(_options.AzureDevopsPAT) ?
+                        new VssBasicCredential(string.Empty, _options.AzureDevopsPAT)
+                        : new VssClientCredentials();
+                        VssConnection connection = new VssConnection(new Uri(_options.AzureDevopsOrganization), credentials);
+
+                        // Create instance of WorkItemTrackingHttpClient using VssConnection
+                        WorkItemTrackingHttpClient witClient = connection.GetClient<WorkItemTrackingHttpClient>();
+
+                        string pattern = @"([>\b \r\n])(#[0-9]+)([<\b \r\n])";
+                        html = Regex.Replace(html, pattern, match => match.Groups[1].Value
+                                                                     + this.generateWorkItemLink(match.Groups[2].Value, witClient).Result
+                                                                     + match.Groups[3].Value);
                     }
 
                     //both mermaid and katex do local rendering
@@ -721,6 +790,48 @@ namespace azuredevops_export_wiki
                 Console.WriteLine(indentString + $"ERR: {msg}");
                 Console.ForegroundColor = color;
             }
+        }
+
+        async private Task<string> generateWorkItemLink(string stringId, WorkItemTrackingHttpClient witClient)
+        {
+            int id;
+            try
+            {
+                id = Int32.Parse(stringId.Replace("#", ""));
+            }
+            catch (FormatException)
+            {
+                Console.WriteLine($"Unable to parse '{stringId}'");
+                return stringId;
+            }
+
+            WorkItem workItem = await witClient.GetWorkItemAsync(id, expand: WorkItemExpand.All);
+            WorkItemType type = await witClient.GetWorkItemTypeAsync(workItem.Fields["System.TeamProject"].ToString(),
+                                                                        workItem.Fields["System.WorkItemType"].ToString());
+
+            string childColor = type.Color;
+            string childIcon = this._iconClass[type.Icon.Id];
+            string url = ((ReferenceLink)workItem.Links.Links["html"]).Href;
+            string title = workItem.Fields["System.Title"].ToString();
+            string state = workItem.Fields["System.State"].ToString();
+            string stateColor = type.States.First(s => s.Name == state).Color;
+
+            return $@"
+            <span class=""mention-widget-workitem"" style=""border-left-color: #{childColor};"">
+                <a class=""mention-link mention-wi-link mention-click-handled"" href=""{url}"">
+                    <span class=""work-item-type-icon-host"">
+                    <i class=""work-item-type-icon bowtie-icon {childIcon}"" role=""figure"" style=""color: #{childColor};""></i>
+                    </span>
+                    <span class=""secondary-text"">{workItem.Id}</span>
+                    <span class=""mention-widget-workitem-title fontWeightSemiBold"">{title}</span>
+                </a>
+                <span class=""mention-widget-workitem-state"">
+                    <span class=""workitem-state-color"" style=""background-color: #{stateColor};""></span>
+                    <span>{state}</span>
+                </span>
+            </span>
+            ";
+            
         }
 
         public class MarkdownFile

--- a/AzureDevOps.WikiPDFExport/azuredevops-export-wiki.csproj
+++ b/AzureDevOps.WikiPDFExport/azuredevops-export-wiki.csproj
@@ -37,6 +37,9 @@
     <PackageReference Include="Markdig" Version="0.24.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.170.0" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />
     <PackageReference Include="RndUsr0.DinkToPdf" Version="1.0.9-20190207.1" />
     <PackageReference Include="PuppeteerSharp" Version="4.0.0" />
   </ItemGroup>

--- a/AzureDevOps.WikiPDFExport/devopswikistyle.css
+++ b/AzureDevOps.WikiPDFExport/devopswikistyle.css
@@ -335,4 +335,138 @@ div.is-caution td,div.is-warning th, div.is-warning td {
     border: none;
 }
 
+.mention-widget-workitem, .mention-widget-workitem-state, .mention-link {
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+}
+
+.secondary-text {
+    color: rgba(0, 0, 0, .55)
+}
+.fontWeightSemiBold {
+    font-weight: 600;
+}
+
+a.mention-link, a.mention-link :hover {
+    text-decoration: none;
+}
+.mention-widget-workitem {
+    font-family: "Segoe UI", Tahoma, sans-serif;
+    font-size: 0.875rem;
+    padding: 2px 0.333em;
+    display: inline;
+    word-break: break-word;
+    margin: 0 1px;
+    /* FIXME: Commented until properly rendered in PDF. See https://github.com/wkhtmltopdf/wkhtmltopdf/issues/5068
+    border-radius: 25%; */
+    line-height: 24px;
+    font-style: normal;
+    font-weight: normal;
+    border-left: 2px solid transparent;
+}
+.mention-widget-workitem-title {
+    color: rgba(0, 0, 0, 0.9);
+}
+.mention-widget-workitem-state {
+    border-left: 1px solid;
+    border-left-color: rgba(200, 200, 200, 1);
+    padding: 0 8px 0 4px;
+    display: inline-flex;
+    align-items: center;
+    margin: 4px 2px 4px 8px;
+    line-height: 24px;
+    vertical-align: bottom;
+    color: rgba(0, 0, 0, 0.9);
+}
+.mention-widget-workitem-state .workitem-state-color {
+    border: 3px solid transparent;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    margin: 0 4px;
+    background-clip: padding-box;
+    box-sizing: border-box;
+}
+.work-item-type-icon-host {
+    display: inline-block;
+}
+.work-item-type-icon-host .work-item-type-icon {
+    min-width: 14px;
+    display: inline;
+}
+
+.bowtie-icon,
+i.bowtie-icon {
+    font-family: "bowtie";
+    font-size: 14px;
+    speak: none;
+    display: inline-block;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    text-align: center;
+    text-decoration: none;
+    line-height: 16px;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.bowtie-brand-github::before{content:"\e916 ";}
+.bowtie-package-fill::before{content:"\e95e ";}
+.bowtie-settings-gear::before{content:"\e98f ";}
+.bowtie-status-error-outline::before{content:"\ea03 ";}
+.bowtie-status-success-box::before{content:"\ea18 ";}
+.bowtie-symbol-airplane::before{content:"\eadb ";}
+.bowtie-symbol-ask::before{content:"\eac2 ";}
+.bowtie-symbol-asterisk::before{content:"\eade ";}
+.bowtie-symbol-book::before{content:"\eac7 ";}
+.bowtie-symbol-bug::before{content:"\eabc ";}
+.bowtie-symbol-car::before{content:"\eadc ";}
+.bowtie-symbol-color-palette::before{content:"\eae4 ";}
+.bowtie-symbol-crown::before{content:"\eabd ";}
+.bowtie-symbol-decision::before{content:"\eae1 ";}
+.bowtie-symbol-defect::before{content:"\eb0c ";}
+.bowtie-symbol-diamond::before{content:"\eadd ";}
+.bowtie-symbol-feedback-request::before{content:"\eae7 ";}
+.bowtie-symbol-feedback-response::before{content:"\eae8 ";}
+.bowtie-symbol-finance::before{content:"\ead8 ";}
+.bowtie-symbol-flame::before, .bowtie-symbol-chat_bubble::before{content:"\eac4 ";}
+.bowtie-symbol-government::before{content:"\eae0 ";}
+.bowtie-symbol-headphone::before{content:"\ead9 ";}
+.bowtie-symbol-impediment::before{content:"\eac1 ";}
+.bowtie-symbol-issue::before{content:"\eb0b ";}
+.bowtie-symbol-key::before{content:"\eada ";}
+.bowtie-symbol-list::before{content:"\eac5 ";}
+.bowtie-symbol-paint-brush::before{content:"\eae3 ";}
+.bowtie-symbol-parachute::before{content:"\eae2 ";}
+.bowtie-symbol-review::before{content:"\eabd ";}
+.bowtie-symbol-review-request::before{content:"\eae5 ";}
+.bowtie-symbol-review-response::before{content:"\eae6 ";}
+.bowtie-symbol-ribbon::before{content:"\ead7 ";}
+.bowtie-symbol-stickynote::before{content:"\eac0 ";}
+.bowtie-symbol-storage-database::before{content:"\eadf ";}
+.bowtie-symbol-task::before{content:"\eabf ";}
+.bowtie-symbol-trophy::before{content:"\eabe ";}
+.bowtie-test-case::before{content:"\eafa ";}
+.bowtie-test-fill::before{content:"\ea19 ";}
+.bowtie-test-parameter::before{content:"\eaca ";}
+.bowtie-test-plan::before{content:"\eac8 ";}
+.bowtie-test-step::before{content:"\eac9 ";}
+.bowtie-test-suite::before{content:"\eacb ";}
+.bowtie-tfvc-pull-request:before{content:"\ea3a ";}
+
+@font-face {
+font-family: "bowtie";
+font-style: normal;
+font-weight: normal;
+src: url("https://cdn.vsassets.io/v/M188_20210713.2/_content/Fonts/Icons/bowtie.eot");
+src: url("https://cdn.vsassets.io/v/M188_20210713.2/_content/Fonts/Icons/bowtie.eot?iefix")
+    format("embedded-opentype"),
+    url("https://cdn.vsassets.io/v/M188_20210713.2/_content/Fonts/Icons/bowtie.woff")
+    format("woff"),
+    url("https://cdn.vsassets.io/v/M188_20210713.2/_content/Fonts/Icons/bowtie.svg#bowtie")
+    format("svg");
+}
 


### PR DESCRIPTION
I'm well advanced in fixing #72, but I'm stuck on rendering differences between wkhtmltopdf and chrome/firefox. I guess it"s because they still use QT 4.

This is the html generated displayed in chrome : 
![image](https://user-images.githubusercontent.com/3317699/126297600-ad719b57-ae50-4766-9f0c-e679c635bdf6.png)
And this is how it's printed in the pdf : 
![image](https://user-images.githubusercontent.com/3317699/126297700-53eb1562-623c-413a-b6ad-a538739c96af.png)

The border is all around the element and text color is blue for some reason. State color could be ignored, as Azure Devops already ignores it when printing a single page to PDF.

Also, we should maybe create a PAT to your devops organization to allow testing of this feature in CI.

- [x] Fix rendering issues
- [ ] Create a read only PAT to https://dev.azure.com/mmelcher
- [ ] Add rendering in test.html
