### PR TITLE
Added ability to export hierarchy for a single file

### DIFF
--- a/AzureDevOps.WikiPDFExport/MarkdownConverter.cs
+++ b/AzureDevOps.WikiPDFExport/MarkdownConverter.cs
@@ -358,6 +358,7 @@ namespace azuredevops_export_wiki
                     {
                         string absPath = null;
                         string anchor = null;
+                        bool isBase64 = false;
 
                         //handle --attachments-path case
                         if (
@@ -387,6 +388,10 @@ namespace azuredevops_export_wiki
                             });
                             absPath = Path.GetFullPath(_wiki.basePath() + linkUrl);
                         }
+                        else if (link.Url.StartsWith("data:"))
+                        {
+                            isBase64 = true;
+                        }
                         else
                         {
                             var split = link.Url.Split("#");
@@ -397,24 +402,28 @@ namespace azuredevops_export_wiki
 
                         //the file is a markdown file, create a link to it
                         var isMarkdown = false;
-                        var fileInfo = new FileInfo(absPath);
-                        if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
+                        if (!isBase64)
                         {
-                            isMarkdown = true;
-                        }
-                        else if (fileInfo.Exists)
-                        {
-                            //convert images to base64 and embed them in the html. Chrome/Puppeter does not show local files because of security reasons.
-                            Byte[] bytes = File.ReadAllBytes(fileInfo.FullName);
-                            String base64 = Convert.ToBase64String(bytes);
 
-                            link.Url = $"data:image/{fileInfo.Extension};base64,{base64}";
-                        }
+                            var fileInfo = new FileInfo(absPath);
+                            if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                isMarkdown = true;
+                            }
+                            else if (fileInfo.Exists)
+                            {
+                                //convert images to base64 and embed them in the html. Chrome/Puppeter does not show local files because of security reasons.
+                                Byte[] bytes = File.ReadAllBytes(fileInfo.FullName);
+                                String base64 = Convert.ToBase64String(bytes);
 
-                        fileInfo = new FileInfo($"{absPath}.md");
-                        if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            isMarkdown = true;
+                                link.Url = $"data:image/{fileInfo.Extension};base64,{base64}";
+                            }
+
+                            fileInfo = new FileInfo($"{absPath}.md");
+                            if (fileInfo.Exists && fileInfo.Extension.Equals(".md", StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                isMarkdown = true;
+                            }
                         }
 
                         //only markdown files get a pdf internal link

--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -109,7 +109,7 @@ namespace azuredevops_export_wiki
                     _wiki = new ExportedWikiDoc(_options.Path);
 
                     IWikiDirectoryScanner scanner = !string.IsNullOrEmpty(_options.Single)
-                        ? new SingleFileScanner(_options.Single, _logger)
+                        ? new SingleFileScanner(_options.Single, _wiki.exportPath(), _options, _logger)
                         : (_options.IncludeUnlistedPages
                             ? new WikiDirectoryScanner(_wiki.exportPath(), _options, _logger)
                             : new WikiOptionFilesScanner(_wiki.exportPath(), _options, _logger));

--- a/AzureDevOps.WikiPDFExport/WikiScanners/SingleFileScanner.cs
+++ b/AzureDevOps.WikiPDFExport/WikiScanners/SingleFileScanner.cs
@@ -1,37 +1,51 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.TeamFoundation.TestManagement.WebApi;
+using Microsoft.TeamFoundation.Wiki.WebApi;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace azuredevops_export_wiki
 {
-    internal class SingleFileScanner : IWikiDirectoryScanner
+    internal class SingleFileScanner : WikiOptionFilesScanner
     {
         private readonly string singleFilePath;
-        private ILogger logger;
 
-        public SingleFileScanner(string filePath, ILogger logger)
+        public SingleFileScanner(string filePath, string wikiPath, Options options, ILogger logger)
+            : base(wikiPath, options, logger) 
         {
             this.singleFilePath = filePath;
-            this.logger = logger;
         }
 
-        public IList<MarkdownFile> Scan()
+        public override IList<MarkdownFile> Scan()
         {
-            var filePath = Path.GetFullPath(singleFilePath);
-            var directory = new DirectoryInfo(Path.GetFullPath(filePath));
+            var allFiles = base.Scan(); 
+            var current = allFiles.FirstOrDefault(m => m.FileRelativePath.Contains(singleFilePath));
+            var idx = allFiles.IndexOf(current);
 
-            if (!File.Exists(filePath))
+            if (current is null || idx == -1)
             {
-                logger.Log($"Single-File [-s] {filePath} specified not found" + filePath, LogLevel.Error);
+                logger.Log($"Single-File [-s] {singleFilePath} specified not found" + singleFilePath, LogLevel.Error);
                 throw new ArgumentException($"{singleFilePath} not found");
             }
+            var result = new List<MarkdownFile>() { current };
 
-            var relativePath = filePath.Substring(directory.FullName.Length);
+            if (allFiles.Count > idx)
+            {
+                foreach (var item in allFiles.Skip(idx + 1))
+                {
+                    if (item.Level > current.Level)
+                    {
+                        result.Add(item);
+                    }
+                    else
+                        break;
+                }
+            }
 
-            return new List<MarkdownFile>() {
-                            new MarkdownFile(new FileInfo(filePath), relativePath, 0, "/")
-                        };
+            return result;
         }
 
     }

--- a/AzureDevOps.WikiPDFExport/WikiScanners/WikiOptionFilesScanner.cs
+++ b/AzureDevOps.WikiPDFExport/WikiScanners/WikiOptionFilesScanner.cs
@@ -12,7 +12,7 @@ namespace azuredevops_export_wiki
         public WikiOptionFilesScanner(string wikiPath, Options options, ILogger logger)
             : base(wikiPath, options, logger) { }
 
-        public IList<MarkdownFile> Scan()
+        public virtual IList<MarkdownFile> Scan()
         {
             return ReadOrderFiles(wikiPath, 0, excludeRegexes); // root level
         }


### PR DESCRIPTION
Updated the scanner to enable the -s option to export not just a single file but also all the child pages that are in the ordered pages.