### PR TITLE
Use local temp folder to download chromium headless

### DIFF
--- a/AzureDevOps.WikiPDFExport/Options.cs
+++ b/AzureDevOps.WikiPDFExport/Options.cs
@@ -59,7 +59,7 @@ namespace azuredevops_export_wiki
         [Option("mermaidjs-path", Required = false, HelpText = "Path of the mermaid.js file. It'll be used if mermaid diagrams support is turned on (-m/--mermaid). If not specified, 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.6.4/mermaid.min.js' will be used.")]
         public string MermaidJsPath { get; set; }
 
-        [Option("chrome-path", Required = false, HelpText = "Path of the chrome or chromium executable. It'll be used if mermaid diagrams support is turned on (-m/--mermaid). If not specified, a headless version will be downloaded.")]
+        [Option("chrome-path", Required = false, HelpText = "Path of the chrome or chromium executable. If not specified, a headless version will be downloaded.")]
         public string ChromeExecutablePath { get; set; }
 
         [Option("chrome-timeout", Required = false, HelpText = "Timeout for Chrome operations in seconds (default 30 seconds).", Default = 30)]

--- a/AzureDevOps.WikiPDFExport/PDFGenerator.cs
+++ b/AzureDevOps.WikiPDFExport/PDFGenerator.cs
@@ -31,16 +31,28 @@ namespace azuredevops_export_wiki
                 output = Path.Combine(Directory.GetCurrentDirectory(), "export.pdf");
             }
 
-            if (string.IsNullOrEmpty(_options.ChromeExecutablePath))
+            string chromePath = _options.ChromeExecutablePath;
+
+            if (string.IsNullOrEmpty(chromePath))
             {
-                _logger.Log("No Chrome path defined, downloading...");
-                _ = await new BrowserFetcher().DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
+                string tempFolder = Path.Join(Path.GetTempPath(), "AzureDevOpsWikiExporter");
+
+                _logger.Log("No Chrome path defined, downloading to user temp...");
+
+                var fetcherOptions = new BrowserFetcherOptions
+                {
+                    Path = tempFolder,
+                };
+
+                var info = await new BrowserFetcher(fetcherOptions).DownloadAsync(BrowserFetcher.DefaultChromiumRevision);
+                chromePath = info.ExecutablePath;
+
                 _logger.Log("Chrome ready.");
             }
 
             var launchOptions = new LaunchOptions
             {
-                ExecutablePath = _options.ChromeExecutablePath ?? string.Empty,
+                ExecutablePath = chromePath,
                 Headless = true, //set to false for easier debugging
                 Args = new[] { "--no-sandbox", "--single-process" }, //required to launch in linux
                 Devtools = false,


### PR DESCRIPTION
The current behaviour of the `BrowserFetcher` class tends to leave instances of the headless chromium browser in a `.localchromium` folder relative to the directory the application is called from.

This PR updates the `BrowserFetcher` to take a `BrowserFetcherOptions` that specifies a directory in the user's local temp folder.

I've also updated the Help text on the `chromePath` option to remove the statement about only used if the Mermaid switch is enabled as this is not true.

Fixes #121 