### PR TITLE
Change default path for devopswikistyle.css

### DIFF
--- a/AzureDevOps.WikiPDFExport/Options.cs
+++ b/AzureDevOps.WikiPDFExport/Options.cs
@@ -56,7 +56,7 @@ namespace azuredevops_export_wiki
         [Option('m', "mermaid", Required = false, HelpText = "Convert mermaid diagrams to SVG. Will download latest chromium, if chrome-path is not defined")]
         public bool ConvertMermaid { get; set; }
 
-        [Option("mermaidjs-path", Required = false, HelpText = "Path of the mermaid.js file. It'll be used if mermaid diagrams support is turned on (-m/--mermaid). If not specified, 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.6.4/mermaid.min.js' will be used.")]
+        [Option("mermaidjs-path", Required = false, HelpText = "Path of the mermaid.js file. It'll be used if mermaid diagrams support is turned on (-m/--mermaid). If not specified, 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.1.6/mermaid.min.js' will be used.")]
         public string MermaidJsPath { get; set; }
 
         [Option("chrome-path", Required = false, HelpText = "Path of the chrome or chromium executable. If not specified, a headless version will be downloaded.")]

--- a/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
+++ b/AzureDevOps.WikiPDFExport/WikiPDFExporter.cs
@@ -203,7 +203,7 @@ namespace azuredevops_export_wiki
                     var cssPath = "";
                     if (string.IsNullOrEmpty(_options.CSS))
                     {
-                        cssPath = "devopswikistyle.css";
+                        cssPath = AppDomain.CurrentDomain.BaseDirectory + "devopswikistyle.css";
                         Log("No CSS specified, using devopswikistyle.css", LogLevel.Information, 0);
                     }
                     else


### PR DESCRIPTION
Fixed: Options description... mermaid version mentioned here needed updating.
Fixed: If calling executable when residing in a different directory the default css page wasn't being found.  Add the executable path in so it finds the default file.